### PR TITLE
Hardcodes enforcement of SSL connections to Enabled

### DIFF
--- a/templates/postgres-paas.json
+++ b/templates/postgres-paas.json
@@ -99,13 +99,6 @@
       "metadata": {
         "description": "The tag"
       }
-    },
-    "sslmode": {
-      "type": "string",
-      "metadata": {
-        "description": "The tag"
-      },
-      "defaultValue": "Disabled"
     }
   },
   "variables":{
@@ -125,7 +118,7 @@
         "version":"[parameters('version')]",
         "administratorLogin":"[parameters('administratorLogin')]",
         "administratorLoginPassword":"[parameters('administratorLoginPassword')]",
-        "sslEnforcement":"[parameters('sslmode')]",
+        "sslEnforcement":"Enabled",
         "storageMB":"[parameters('skuSizeMB')]"
       },
       "sku":{


### PR DESCRIPTION
### Change description ###
Applying this change will prevent any Postgres PaaS dbs being created without SSL connections being enforced.
It will still be possible to turn off SSL connection enforcement via the portal after initial creation.

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes - Potentially if your client doesn't support ssl connections but we don't want those kind of clients here thanks
[ ] No
```
