### PR TITLE
Perform only linting on the modules for now

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ try {
     }
 
     stage('Terraform Linting Checks') {
-      sh "terraform validate -var 'product=product' -var 'location=location' -var 'env=env' -var 'postgresql_user=user'"
+      sh 'terraform validate -check-variables=false -no-color'
     }
   }
 }


### PR DESCRIPTION
Cut down the jenkinsfile to only linting to reduce false negatives.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
