### PR TITLE
Adds lastUpdated timestamp tag to the resource group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,8 @@ resource "azurerm_resource_group" "data-resourcegroup" {
   location = "${var.location}"
 
   tags {
-    environment = "${var.env}"
+    environment = "${var.env}",
+    lastUpdated = "${timestamp()}"
   }
 }
 


### PR DESCRIPTION
### JIRA link ###


### Change description ###
Adds the lastUpdated timestamp to the resource group for the postgres dbs.  This is an in-place (non breaking) change:
https://build.platform.hmcts.net/job/HMCTS/job/moj-rhubarb-recipes-service/job/PR-70/8/consoleFull

    11:57:54 ------------------------------------------------------------------------
    11:57:57 
    11:57:57 An execution plan has been generated and is shown below.
    11:57:57 Resource actions are indicated with the following symbols:
    11:57:57   ~ update in-place
    11:57:57 
    11:57:57 Terraform will perform the following actions:
    11:57:57 
    11:57:57   ~ module.recipe-backend.azurerm_resource_group.rg
    11:57:57       tags.lastUpdated: "2018-06-13T10:23:35Z" => "2018-06-13T10:57:56Z"
    11:57:57 
    11:57:57   ~ module.recipe-database.azurerm_resource_group.data-resourcegroup
    11:57:57       tags.lastUpdated: "2018-06-13T10:23:35Z" => "2018-06-13T10:57:56Z"
    11:57:57 
    11:57:57 
    11:57:57 Plan: 0 to add, 2 to change, 0 to destroy.
    11:57:57 
    11:57:57 ------------------------------------------------------------------------
    11:57:57 
    11:57:57 Note: You didn't specify an "-out" parameter to save this plan, so Terraform
    11:57:57 can't guarantee that exactly these actions will be performed if
    11:57:57 "terraform apply" is subsequently run.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
