### PR TITLE
RDM-2318 configure slow query logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The following parameters are optional
 - `firewall_rule_name` name of the firewall rule. Default is "allow_all".
 - `firewall_start_ip` start ip for the firewall rule. Default is "0.0.0.0".
 - `firewall_end_ip` end ip for the firewall rule. Default is "0.0.0.0".
+- `log_min_duration_statement` log SQL statements that take more than this many
+  milliseconds to execute. Default is to not log slow statements.
 
 ### Output
 

--- a/main.tf
+++ b/main.tf
@@ -44,5 +44,6 @@ resource "azurerm_template_deployment" "postgres-paas" {
     firewallEndIpAddress       = "${var.firewall_end_ip}"
     charset                    = "${var.charset}"
     collation                  = "${var.collation}.${var.charset}"
+    log_min_duration_statement = "${var.log_min_duration_statement}"
   }
 }

--- a/templates/postgres-paas.json
+++ b/templates/postgres-paas.json
@@ -128,6 +128,10 @@
     },
     "collation": {
       "type": "string"
+    },
+    "log_min_duration_statement": {
+      "type": "string",
+      "defaultValue": -1
     }
   },
   "resources": [
@@ -176,6 +180,17 @@
           "properties": {
             "charset": "[parameters('charset')]",
             "collation": "[parameters('collation')]"
+          },
+          "dependsOn": [
+            "[concat('Microsoft.DBforPostgreSQL/servers/', parameters('serverName'))]"
+          ]
+        },
+        {
+          "type": "configurations",
+          "name": "log_min_duration_statement",
+          "apiVersion": "2017-12-01-preview",
+          "properties": {
+            "value": "[parameters('log_min_duration_statement')]"
           },
           "dependsOn": [
             "[concat('Microsoft.DBforPostgreSQL/servers/', parameters('serverName'))]"

--- a/variables.tf
+++ b/variables.tf
@@ -119,3 +119,8 @@ variable "database_name" {
 variable "common_tags" {
   type = "map"
 }
+
+variable "log_min_duration_statement" {
+  description = "Queries running longer than this time will be logged (ms) (-1 to disable)"
+  default = "-1"
+}


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/RDM-2318

### Change description ###

Add initial code to enable configuration of `log_min_duration_statement`, default is disabled.

This was done so that we could find and fix long running queries and I wanted to do this without fiddling with deployed database settings outside of Terraform.

I've tested this on ccd-definition-store-api-sandbox to validate that the configuration changes.

I'm sure there is a more general way using Terraform templates to create the needed snippets and thus make it easy to configure any PostgreSQL option, but this was the one I needed to have quickly.  

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
