### PR TITLE
SIDM-2146: added skuCapacity variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,6 +72,7 @@ resource "azurerm_template_deployment" "postgres-paas" {
     serverName                 = "${var.product}-${var.env}"
     dbName                     = "${replace(var.database_name, "-", "")}"
     skuName                    = "${var.sku_name}"
+    skuCapacity                = "${var.sku_capacity}"
     skuTier                    = "${var.sku_tier}"
     version                    = "${var.postgresql_version}"
     skuSizeMB                  = "${var.storage_mb}"

--- a/templates/postgres-paas.json
+++ b/templates/postgres-paas.json
@@ -34,7 +34,7 @@
       "maxLength":63
     },
     "skuCapacity": {
-      "type":"int",
+      "type":"string",
       "defaultValue": 2
     },
     "skuFamily": {

--- a/variables.tf
+++ b/variables.tf
@@ -46,6 +46,13 @@ variable "sku_tier" {
   default = "GeneralPurpose"
 }
 
+# This is actually the vCores when template is run
+variable "sku_capacity" {
+  type = "string"
+  default = "2"
+}
+
+
 # Valid values are 9.5, 9.6 and 10.
 variable "postgresql_version" {
   type    = "string"


### PR DESCRIPTION
skuCapacity (Vcores) is missing and defaults to 2, this causes terraform
to fail if a skuName (size) with more than 2 vcores is selected

