### PR TITLE
Make subscription a required variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -113,6 +113,5 @@ variable "common_tags" {
 }
 
 variable "subscription" {
-  default     = ""
   description = "the human friendly name of the subscription, ie. qa, or prod"
 }


### PR DESCRIPTION
### Change description ###
Subscription is now a required variable

To pass it through you need to add:
```
subscription = "${var.subscription}"
```

see usage for a full example

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
