### PR TITLE
SIDM-6311 adding resource group to the output variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The following variables are provided by the module for use in other modules
 - `user_name` the username given in `postgresql_user` combined with the server name in the format postgresql_user@postgres-paas.name
 - `postgresql_database`
 - `postgresql_password` the randomly generated password for the admin login. It will be 16 characters and contain characters from three of the following categories: English uppercase letters, English lowercase letters, numbers (0 through 9), and nonalphanumeric characters (!, $, #, %, etc.).
+- `resource_group_name` the resource group name of the PostgreSQL database resource
+- `name` the server name of the PostgreSQL database resource
 
 
 ## Access to databases

--- a/output.tf
+++ b/output.tf
@@ -25,3 +25,7 @@ output "db_subnet_rules" {
 output "name" {
   value = azurerm_template_deployment.postgres-paas.name
 }
+
+output "resource_group_name" {
+  value = azurerm_template_deployment.postgres-paas.resource_group_name
+}


### PR DESCRIPTION
The resource group name is required when creating a `azurerm_postgresql_configuration` resource