### PR TITLE
Add propagated delay

### DIFF
--- a/set-postgres-permissions.bash
+++ b/set-postgres-permissions.bash
@@ -31,10 +31,10 @@ while true; do
    if [[ $? -eq 0 ]]; then
       break
    fi
-   if [[ $COUNT -eq $MAX ]] then
+   if [[ $COUNT -eq $MAX ]]; then
       break
    else
-      $COUNT = $COUNT + 1
+      COUNT=$[$COUNT+1]
    fi
    sleep 5
 done

--- a/set-postgres-permissions.bash
+++ b/set-postgres-permissions.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export AZURE_CONFIG_DIR=~/.azure-db-manager
-az login -u "${DB_MANAGER_USER_NAME}" -p "${DB_MANAGER_PASSWORD}" -t "${TENANT_ID}" > /dev/null
+az login -u "${DB_MANAGER_USER_NAME}" -p "${DB_MANAGER_PASSWORD}" -t "${TENANT_ID}" >/dev/null
 
 # shellcheck disable=SC2155
 export PGPASSWORD=$(az account get-access-token --resource-type oss-rdbms --query accessToken -o tsv)
@@ -22,5 +22,21 @@ END
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO PUBLIC;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO \"${DB_READER_USER}\";
 "
+
+## Delay until DB DNS and propagated 
+COUNT=0;
+MAX=10;
+while true; do
+   ping -c 1 $DB_HOST_NAME &>/dev/null
+   if [[ $? -eq 0 ]]; then
+      break
+   fi
+   if [[ $COUNT -eq $MAX ]] then
+      break
+   else
+      $COUNT = $COUNT + 1
+   fi
+   sleep 5
+done
 
 psql "sslmode=require host=${DB_HOST_NAME} dbname=${DB_NAME} user=${DB_USER}" -c "${SQL_COMMAND}"


### PR DESCRIPTION
### Change description ###
Currently after it deployed the Database and then tries to add the user, it fails as the DNS for the Database has not yet propagated.
This code should delay the user being added for it to then action.

Failed example here: https://sds-build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_PIP%2Fpip-subscription-management/detail/master/11/pipeline


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
