### PR TITLE
Add replica option for postgres database

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ additional_databases = [
     "postgresql-db3",
 ]
 ```
+### Creating replicas of PostgreSQL instance 
+
+Replicas of PostgreSQL instance can be created by using the variable `replicas`
+
+Example of variable `replicas` being referenced
+
+```terraform
+replicas = [
+    "replica01",
+    "replica02",
+]
+```
 
 ## Variables
 

--- a/replicas.tf
+++ b/replicas.tf
@@ -23,8 +23,8 @@ resource "azurerm_postgresql_server" "replica" {
   )
 
   name                = "local.server_name-${each.key}"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.data-resourcegroup.location
+  resource_group_name = azurerm_resource_group.data-resourcegroup.name
 
   sku_name   = var.sku_name
   version    = var.postgresql_version
@@ -54,7 +54,7 @@ resource "azurerm_postgresql_virtual_network_rule" "replica_rules" {
   )
 
   name                                 = each.value.rule_name
-  resource_group_name                  = azurerm_resource_group.rg.name
+  resource_group_name                  = azurerm_resource_group.data-resourcegroup.name
   server_name                          = azurerm_postgresql_server.replica[each.value.server_name].name
   subnet_id                            = each.value.subnet_id
   ignore_missing_vnet_service_endpoint = true

--- a/replicas.tf
+++ b/replicas.tf
@@ -1,0 +1,61 @@
+locals {
+  replica_db_rules = flatten([for replica in var.replica_name :
+    [for network_rule in local.db_rules :
+      {
+        "rule_name"   = "${replica}-${network_rule.rule_name}"
+        "server_name" = replica
+        "subnet_id"   = network_rule.subnet_id
+      }
+    ]
+  ])
+}
+
+data "azurerm_postgresql_server" "replica" {
+  name                = local.server_name
+  resource_group_name = azurerm_resource_group.data-resourcegroup.name
+}
+
+resource "azurerm_postgresql_server" "replica" {
+  for_each = (
+    var.replica_enable == true ?
+    { for replica in var.replica_name : replica => replica } :
+    {}
+  )
+
+  name                = "local.server_name-${each.key}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  sku_name   = var.sku_name
+  version    = var.postgresql_version
+  storage_mb = var.storage_mb
+
+  backup_retention_days        = var.backup_retention_days
+  geo_redundant_backup_enabled = var.georedundant_backup
+
+  ssl_enforcement_enabled          = var.ssl_enforcement
+  ssl_minimal_tls_version_enforced = "TLS1_2"
+
+  administrator_login          = var.postgresql_user
+  administrator_login_password = random_string.password.result
+
+  create_mode               = "Replica"
+  creation_source_server_id = data.azurerm_postgresql_server.replica.id
+
+  tags = var.common_tags
+}
+
+resource "azurerm_postgresql_virtual_network_rule" "example" {
+
+  for_each = (
+    var.create_replica == true ?
+    { for db_rule in local.replica_db_rules : db_rule.rule_name => db_rule } :
+    {}
+  )
+
+  name                                 = each.value.rule_name
+  resource_group_name                  = azurerm_resource_group.rg.name
+  server_name                          = azurerm_postgresql_server.replica[each.value.server_name].name
+  subnet_id                            = each.value.subnet_id
+  ignore_missing_vnet_service_endpoint = true
+}

--- a/replicas.tf
+++ b/replicas.tf
@@ -22,7 +22,7 @@ resource "azurerm_postgresql_server" "replica" {
     {}
   )
 
-  name                = "local.server_name-${each.key}"
+  name                = "${local.server_name}-${each.key}"
   location            = azurerm_resource_group.data-resourcegroup.location
   resource_group_name = azurerm_resource_group.data-resourcegroup.name
 

--- a/replicas.tf
+++ b/replicas.tf
@@ -48,7 +48,7 @@ resource "azurerm_postgresql_server" "replica" {
 resource "azurerm_postgresql_virtual_network_rule" "replica_rules" {
 
   for_each = (
-    var.create_replica == true ?
+    var.replica_enable == true ?
     { for db_rule in local.replica_db_rules : db_rule.rule_name => db_rule } :
     {}
   )

--- a/replicas.tf
+++ b/replicas.tf
@@ -45,7 +45,7 @@ resource "azurerm_postgresql_server" "replica" {
   tags = var.common_tags
 }
 
-resource "azurerm_postgresql_virtual_network_rule" "example" {
+resource "azurerm_postgresql_virtual_network_rule" "replica_rules" {
 
   for_each = (
     var.create_replica == true ?

--- a/replicas.tf
+++ b/replicas.tf
@@ -31,9 +31,9 @@ resource "azurerm_postgresql_server" "replica" {
   storage_mb = var.storage_mb
 
   backup_retention_days        = var.backup_retention_days
-  geo_redundant_backup_enabled = var.georedundant_backup
+  geo_redundant_backup_enabled = var.georedundant_backup == "Enabled" ? true : false
 
-  ssl_enforcement_enabled          = var.ssl_enforcement
+  ssl_enforcement_enabled          = var.ssl_enforcement == "Enabled" ? true : false
   ssl_minimal_tls_version_enforced = "TLS1_2"
 
   administrator_login          = var.postgresql_user

--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,6 @@ variable "replicas" {
   default     = []
 }
 
-
 variable "postgresql_listen_port" {
   type    = string
   default = "5432"

--- a/variables.tf
+++ b/variables.tf
@@ -22,13 +22,11 @@ variable "additional_databases" {
   default = []
 }
 
-variable "replica_enable" {
-  default = false
+variable "replicas" {
+  description = "Names of any database replicas"
+  default     = []
 }
 
-variable "replica_name" {
-  default = []
-}
 
 variable "postgresql_listen_port" {
   type    = string

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,16 @@ variable "env" {
 }
 
 variable "additional_databases" {
-  default     = []
+  default = []
+}
+
+variable "replica_enable" {
+  type    = boolean
+  default = false
+}
+
+variable "replica_name" {
+  default = []
 }
 
 variable "postgresql_listen_port" {

--- a/variables.tf
+++ b/variables.tf
@@ -23,7 +23,6 @@ variable "additional_databases" {
 }
 
 variable "replica_enable" {
-  type    = boolean
   default = false
 }
 


### PR DESCRIPTION
### Change description ###
Add replica option for postgres database

Tested on a PoC that database permissions are replicated, example `tamops` / `tamopsnew` roles copied to replicated database
```
exampledb=> \du
                                                  List of roles
            Role name            |                         Attributes                         |    Member of     
---------------------------------+------------------------------------------------------------+------------------
 azure_pg_admin                  | Cannot login, Replication                                  | {}
 azure_replication_user_9d4606f8 | Replication                                                | {}
 azure_superuser                 | Superuser, Create role, Create DB, Replication, Bypass RLS | {}
 psqladmin                       | Create role, Create DB, Replication                        | {azure_pg_admin}
 tamops                          | Cannot login                                               | {}
 tamopsnew                       | Cannot login                                               | {}
```
 

**Does this PR introduce a breaking change?** (check one with "x")


```
[ ] Yes
[X] No
```
