### PR TITLE
default geo_redundant_backup_enable is true for replica

### DIFF
--- a/replicas.tf
+++ b/replicas.tf
@@ -27,7 +27,7 @@ resource "azurerm_postgresql_server" "replica" {
   storage_mb = var.storage_mb
 
   backup_retention_days        = var.backup_retention_days
-  geo_redundant_backup_enabled = false
+  geo_redundant_backup_enabled = var.replica_geo_redundant_backup_enabled
 
   ssl_enforcement_enabled          = var.ssl_enforcement == "Enabled" ? true : false
   ssl_minimal_tls_version_enforced = "TLS1_2"

--- a/variables.tf
+++ b/variables.tf
@@ -105,6 +105,10 @@ variable "backup_retention_days" {
   default = "35"
 }
 
+variable "replica_geo_redundant_backup_enabled" {
+  default = true
+}
+
 # Possible values are Enabled and Disabled.
 variable "georedundant_backup" {
   type    = string


### PR DESCRIPTION
### Change description ###
default geo_redundant_backup_enable is true for replica.

Currently it tries to 
`geo_redundant_backup_enabled      = true -> false # forces replacement`

Slack thread 
https://hmcts-reform.slack.com/archives/C8SR5CAMU/p1663927799294359 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
